### PR TITLE
CI: Use github CI instead of travis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: on ruby ${{matrix.ruby}}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [jruby-9.3.8.0]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{matrix.ruby}}
+
+    - name: Install dependencies
+      run: bundle install --jobs 4 --retry 3
+
+    - name: Specs
+      run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v '< 2'
-  - gem install jbundler
-rvm:
-  - jruby-9.2.9.0
-jdk:
-  - openjdk8


### PR DESCRIPTION
Travis is dead and isn't building anymote, lets use github CI

Here is an example build: https://github.com/ylecuyer/ruby-band/actions/runs/3158913723/jobs/5141494430

I also have the failure locally, we will have to fix the spec after this merge