### PR TITLE
Fix Random ancestor issue for jruby-9.4.8.0

### DIFF
--- a/band_server/simple_server.rb
+++ b/band_server/simple_server.rb
@@ -76,7 +76,7 @@ class Trial < Sinatra::Base
     classifier = session[:classifiers][params[:model_name]]
     fold = params[:fold].to_i
     eval = Weka::Classifier::Evaluation.new classifier.instance_eval("@dataset")
-    eval.crossValidateModel(classifier.class.new, classifier.instance_eval("@dataset"), fold.to_java(:int), Random.new(1))
+    eval.crossValidateModel(classifier.class.new, classifier.instance_eval("@dataset"), fold.to_java(:int), java.util.Random.new(1))
     eval.summary
   end
 

--- a/lib/ruby-band.rb
+++ b/lib/ruby-band.rb
@@ -6,6 +6,3 @@ require "java"
 require "ruby-band/core"
 require "ruby-band/weka"
 require "ruby-band/apache"
-Random.ancestors[1].instance_eval {remove_const :Random} if defined?(Random)
-java_import 'java.util.Random'
-

--- a/lib/ruby-band/weka/classifiers/bayes/bayes_utils.rb
+++ b/lib/ruby-band/weka/classifiers/bayes/bayes_utils.rb
@@ -52,11 +52,11 @@ module Bayes_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end

--- a/lib/ruby-band/weka/classifiers/functions/functions_utils.rb
+++ b/lib/ruby-band/weka/classifiers/functions/functions_utils.rb
@@ -51,11 +51,11 @@ module Functions_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end

--- a/lib/ruby-band/weka/classifiers/lazy/lazy_utils.rb
+++ b/lib/ruby-band/weka/classifiers/lazy/lazy_utils.rb
@@ -56,11 +56,11 @@ module Lazy_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end

--- a/lib/ruby-band/weka/classifiers/mi/mi_utils.rb
+++ b/lib/ruby-band/weka/classifiers/mi/mi_utils.rb
@@ -53,11 +53,11 @@ module Mi_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end

--- a/lib/ruby-band/weka/classifiers/rules/rules_utils.rb
+++ b/lib/ruby-band/weka/classifiers/rules/rules_utils.rb
@@ -54,11 +54,11 @@ module Rules_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end

--- a/lib/ruby-band/weka/classifiers/trees/trees_utils.rb
+++ b/lib/ruby-band/weka/classifiers/trees/trees_utils.rb
@@ -55,11 +55,11 @@ module Trees_utils
   def cross_validate(fold)
     if self.class.data
       eval = Weka::Classifier::Evaluation.new self.class.data
-      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[2].new, self.class.data, fold.to_java(:int), java.util.Random.new(1))
       eval.summary 
     else
       eval = Weka::Classifier::Evaluation.new @dataset
-      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), Random.new(1))
+      eval.crossValidateModel(self.class.ancestors[1].new, @dataset, fold.to_java(:int), java.util.Random.new(1))
       eval.summary
     end
   end


### PR DESCRIPTION
It was never a good idea to use hardcoded "1" value in ancestors to remove Random in the first place because ancestors can change and it's what happened with new jruby version. Moreover the fact Random ruby is replaced in all ruby object makes a big side effect. With jruby update the SecureRandom has changed and try to call urandom on the java Random class and fail.

This commit remove the java import and use full namespace instead.